### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Run the following command to start
 ```
-docker run -it -p 8000:8000 sanjose/docusaurus npm start -- --port 8000
+docker run -it -p 3000:3000 sanjose/docusaurus npm start --host 0.0.0.0
 ```
 where -p defines the port number exposed, and
 -- --port <port> defines the port number the server runs


### PR DESCRIPTION
While trying to run the Docker image, I encountered two issues:
1. The service was running on localhost inside the container. 
2. The port mapping `--port 8000` as described in the `README.md` had no effect.

As a result of number 1, the server was not reachable with docker-toolbox on Mac, which runs Docker inside of a virtual machine.
Number 2 meant, that the server was always running on port 3000, no matter what port was specified on the command line.

As a result, I've adjusted the docs to the settings that should work in any environment (Linux, Mac, Windows). The only disadvantage is that we're binding to `0.0.0.0`, which means that the server gets exposed to external hosts. If that is undesirable, we could also change the wording like so:

    ## Run the following command to start
    ```
    docker run  -p 3000:3000 sanjose/docusaurus npm start
     ```

    If you're using Docker toolbox (on Mac or Windows), you might need to bind to `0.0.0.0`  instead:
    ```
    docker run -p 3000:3000 sanjose/docusaurus npm start --host 0.0.0.0
     ```

Note, that I removed `-it` and the port mapping, since that's not needed. 😉 